### PR TITLE
pass speed, runCallbacks and internal to slideTo() method

### DIFF
--- a/src/core/slide/slideNext.mjs
+++ b/src/core/slide/slideNext.mjs
@@ -24,5 +24,5 @@ export default function slideNext(speed = this.params.speed, runCallbacks = true
   if (params.rewind && swiper.isEnd) {
     return swiper.slideTo(0, speed, runCallbacks, internal);
   }
-  return swiper.slideTo(swiper.activeIndex + increment);
+  return swiper.slideTo(swiper.activeIndex + increment, speed, runCallbacks, internal);
 }


### PR DESCRIPTION
Fix of issue #7060, following the solution proposed by @kruboy14 in https://github.com/nolimits4web/swiper/issues/7060#issuecomment-1732991729_
speed, runCallbacks and internal are passed again in the swiper.slideTo() method